### PR TITLE
add the ollama module to home-manager

### DIFF
--- a/users/common/ollama.nix
+++ b/users/common/ollama.nix
@@ -1,0 +1,10 @@
+{ pkgs, config, ... }:
+{
+  services.ollama = {
+    enable = true;
+    port = 11434;
+    host = "127.0.0.1";
+    acceleration = "cuda";
+    package = config.lib.nixGL.wrapOffload pkgs.ollama;
+  };
+}


### PR DESCRIPTION
this adds the ollama module to home-manager, feel free to add it to any user that requires ollama running locally
this does not activate the module for any users out of the box
