### PR TITLE
Add Atuin Server

### DIFF
--- a/common/hm/atuin.nix
+++ b/common/hm/atuin.nix
@@ -13,7 +13,7 @@
       sync = {
         # Configure automatic synchronization
         enabled = false;
-        # address = "https://sync.youratuinserver.com"; # Change this to your Atuin server address
+        address = "https://atuin.nothing.ltd";
         # auth_key = "your-auth-key-here"; # Your authentication key
       };
     };

--- a/common/os/containers/atuin-server.nix
+++ b/common/os/containers/atuin-server.nix
@@ -1,0 +1,66 @@
+{
+  pkgs,
+  opts,
+  ...
+}:
+{
+
+  networking.firewall.allowedTCPPorts = builtins.map pkgs.lib.strings.toInt (
+    with opts.ports; [ atuin-server ]
+  );
+
+  systemd.tmpfiles.rules = [
+    "d ${opts.paths.app-dbs}/atuin 0755 ${opts.adminUID} ${opts.adminGID} -"
+    "d ${opts.paths.app-data}/atuin 0755 ${opts.adminUID} ${opts.adminGID} -"
+  ];
+
+  virtualisation.oci-containers.containers = {
+    atuin-server = {
+      autoStart = true;
+      image = "ghcr.io/atuinsh/atuin:latest";
+      extraOptions = [
+        "--add-host=${opts.hostname}:${opts.lanAddress}"
+        "--no-healthcheck"
+      ];
+      volumes = [
+        "${opts.paths.app-data}/atuin:/config"
+      ];
+      ports = [
+        "${opts.ports.atuin-server}:8888"
+      ];
+      cmd = [
+        "server"
+        "start"
+      ];
+      dependsOn = [ "atuin-db" ];
+      environmentFiles = [ ];
+      environment = {
+        ATUIN_HOST = "0.0.0.0";
+        ATUIN_OPEN_REGISTRATION = "true";
+        RUST_LOG = "info,atuin_server=debug";
+        PGID = opts.adminGID;
+        PUID = opts.adminUID;
+        TZ = opts.timeZone;
+        # FIX: PLEASE MOVE THIS TO AGENIX BEFORE AND SET VALUES BEFORE MERGING
+        ATUIN_DB_URI = "postgres://$ATUIN_DB_USERNAME:$ATUIN_DB_PASSWORD@db/$ATUIN_DB_NAME";
+      };
+    };
+    atuin-db = {
+      autoStart = false;
+      image = "postgres:14";
+      volumes = [
+        "${opts.paths.app-dbs}/atuin:/var/lib/postgresql/data/"
+      ];
+      environmentFiles = [ ];
+      environment = {
+        # FIX: PLEASE MOVE THIS TO AGENIX BEFORE AND SET VALUES BEFORE MERGING
+        POSTGRES_USER = "\${ATUIN_DB_USERNAME}";
+        POSTGRES_PASSWORD = "\${ATUIN_DB_PASSWORD}";
+        POSTGRES_DB = "\${ATUIN_DB_NAME}";
+        PGID = opts.adminGID;
+        PUID = opts.adminUID;
+        TZ = opts.timeZone;
+      };
+    };
+  };
+}

--- a/common/os/containers/default.nix
+++ b/common/os/containers/default.nix
@@ -2,6 +2,7 @@
 {
   imports = [
     ./archive-warrior.nix
+    ./atuin-server.nix
     ./audiobookshelf.nix
     ./filebrowser.nix
     ./flaresolverr.nix

--- a/hosts/athena0/opts.nix
+++ b/hosts/athena0/opts.nix
@@ -39,6 +39,7 @@ rec {
   ports = {
     nextcloud-https = "444";
     audiobookshelf = "13378";
+    atuin-server = "8888";
     filebrowser = "9008";
     flare-solverr = "8191";
     grafana = "2200";


### PR DESCRIPTION
This PR adds the atuin server through a docker container. please make sure to setup the agenix component before merging.

you also need to add an nginx entry for `atuin.nothing.ltd` pointing to port number `8888`.
and maybe make some tweaks to the client settings.

The secrets file should contain the following values:
```
ATUIN_DB_NAME=atuin
ATUIN_DB_USERNAME=atuin
ATUIN_DB_PASSWORD=really-insecure
POSTGRES_USER="${ATUIN_DB_USERNAME}"
POSTGRES_PASSWORD="${ATUIN_DB_PASSWORD}"
POSTGRES_DB="${ATUIN_DB_NAME}"
ATUIN_DB_URI = "postgres://${ATUIN_DB_USERNAME}:${ATUIN_DB_PASSWORD}@db/${ATUIN_DB_NAME}";
```