### PR TITLE
Custom NixGL with nvidia mirror override

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -181,15 +181,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1752054764,
-        "narHash": "sha256-Ob/HuUhANoDs+nvYqyTKrkcPXf4ZgXoqMTQoCK0RFgQ=",
-        "owner": "nix-community",
+        "lastModified": 1757844178,
+        "narHash": "sha256-EsXPSBKyGFHfvXPE3ToLHlEFancNcRDcT6Et+RJAouk=",
+        "owner": "sreedevk",
         "repo": "nixGL",
-        "rev": "a8e1ce7d49a149ed70df676785b07f63288f53c5",
+        "rev": "4357bf437f2e8859c276248d966a9d1a21b380e7",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
+        "owner": "sreedevk",
         "repo": "nixGL",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
     };
 
     nixgl = {
-      url = "github:nix-community/nixGL";
+      url = "github:sreedevk/nixGL";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/users/carcosa/default.nix
+++ b/users/carcosa/default.nix
@@ -18,7 +18,7 @@ in
   ];
 
   nixGL = {
-    inherit (inputs.nixgl) packages;
+    packages = pkgs.nixgl;
     defaultWrapper = "mesa";
     offloadWrapper = "nvidia";
     vulkan.enable = true;

--- a/users/overlays/default.nix
+++ b/users/overlays/default.nix
@@ -4,4 +4,5 @@
   (import ./agenix.nix { inherit inputs; })
   (import ./stable.nix { inherit inputs; })
   (import ./wezterm.nix { inherit inputs; })
+  (import ./nvidia.nix { inherit inputs; })
 ]

--- a/users/overlays/nvidia.nix
+++ b/users/overlays/nvidia.nix
@@ -1,0 +1,6 @@
+{ ... }:
+final: prev: {
+  nixgl = prev.nixgl.override {
+    nvidiaURL = "https://us.download.nvidia.com/XFree86/Linux-x86_64";
+  };
+}


### PR DESCRIPTION
sometimes, when you update the kernel, the associated nvidia driver version download attempt by nixGL fails. Changing the
nvidia driver download mirror fixes the issue for me (though the issue might be deeper - inconsistent nvidia versioning).

unfortunately, the default nixGL package does not allow overriding the nvidia mirror. so I forked it and added that as an
overridable attribute. here I've swapped out the nix-community/nixGL flake with my sreedevk/nixGL flake and added the
overlay that overrides the nvidiaURL attribute. I've tested it on my own setup and this should work as expected
