### PR TITLE
Brave Browser (Screensharing Enabled Browser)

### DIFF
--- a/common/hm/brave.nix
+++ b/common/hm/brave.nix
@@ -1,0 +1,40 @@
+{ pkgs, config, ... }:
+let
+  nixgl-brave-pkg = config.lib.nixGL.wrap pkgs.brave;
+in
+{
+  home.packages = [ nixgl-brave-pkg ];
+  xdg.desktopEntries = {
+    brave-browser = {
+      name = "Brave";
+      icon = "brave-browser";
+      genericName = "Web Browser";
+      exec = "env __NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia ${nixgl-brave-pkg}/bin/brave %U";
+      comment = "Access the Internet";
+      mimeType = [
+        "application/pdf"
+        "application/rdf+xml"
+        "application/rss+xml"
+        "application/xhtml+xml"
+        "application/xhtml_xml"
+        "application/xml"
+        "image/gif"
+        "image/jpeg"
+        "image/png"
+        "image/webp"
+        "text/html"
+        "text/xml"
+        "x-scheme-handler/http"
+        "x-scheme-handler/https"
+        "x-scheme-handler/ipfs"
+        "x-scheme-handler/ipns"
+      ];
+      terminal = false;
+      type = "Application";
+      categories = [
+        "Network"
+        "WebBrowser"
+      ];
+    };
+  };
+}

--- a/hosts/pop-os/users/carcosa/default.nix
+++ b/hosts/pop-os/users/carcosa/default.nix
@@ -13,6 +13,7 @@
     ../../../../common/hm/mise.nix
     ../../../../common/hm/wezterm.nix
     ../../../../common/hm/zathura.nix
+    ../../../../common/hm/brave.nix
   ];
 
   nixGL = {


### PR DESCRIPTION
firefox module added in a previous PR was written to run on the nvidia GPU.
brave browser added in this PR runs on the integrated GPU which runs on wayland without screensharing issues.
